### PR TITLE
Support for author string in package.json

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,32 @@ module.exports = function(verb) {
       throw new Error('No config object or "package.json" was found', e);
     }
   }
+  
+  // If package.json has an author string instead of an author object, 
+  // split the string so the data can be used in templates.
+  if (typeof data.author === 'string') {
+    var authorString = data.author;
+    
+    // Split the string into an array.
+    authorArray = authorString.split(/<|>/);
+    
+    // Clean up the name and URL strings, but only if they exist.
+    if (authorArray[0]) {
+      authorArray[0] = authorArray[0].slice(0, -1);
+    } else if (authorArray[2]) {
+      authorArray[2] = authorArray[2].substr(2).slice(0, -1); 
+    };
+    
+    // Create the new author object
+    var author = {
+      name: authorArray[0],
+      email: authorArray[1],
+      url: authorArray[2]
+    };
+    
+    // Update the data object
+    data.author = author; 
+  };
 
   return data;
 };


### PR DESCRIPTION
Allows one to use `{%= author.name %}`, `{%= author.email%}` and/or `{%= author.url %}` whether they use the string format (`"Full Name <email> (url)"`) or object format (`{ "name" : "foo", "email" : "email@foo.com", "url" : "baz.com"}`) of the author data in package.json.
