### PR TITLE
Pass "showStack:true"  to PluginError

### DIFF
--- a/lib/plugins/render.js
+++ b/lib/plugins/render.js
@@ -28,7 +28,7 @@ module.exports = function(locals) {
       var stream = this;
       app.render(file, locals, function (err, content) {
         if (err) {
-          stream.emit('error', new PluginError('render plugin', err, {stack: true}));
+          stream.emit('error', new PluginError('render plugin', err, {showStack: true}));
           return cb(err);
         }
         file.contents = new Buffer(content);
@@ -36,7 +36,7 @@ module.exports = function(locals) {
         return cb();
       });
     } catch (err) {
-      this.emit('error', new PluginError('render plugin', err, {stack: true}));
+      this.emit('error', new PluginError('render plugin', err, {showStack: true}));
       return cb();
     }
   });


### PR DESCRIPTION
For #64 : Assuming that  doowb/async-helpers#6
PluginErrors created by the render-plugin should contain the stack-trace of the original error so that it can be displayed in an error-handler of  the in the verbfile:

```js
verb.task('default', function () {
  verb.src(['.verb.md'])
    .pipe(verb.dest('./'))
    .on("error", function(err) {
      console.log(err.stack);
    });
}}
```