### PR TITLE
Error in documentation, "Built by verb"

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -8,7 +8,7 @@ The follow projects use verb to build the reamde and other docs:
 
 - [micromatch](https://github.com/jonschlinkert/micromatch/) (1.7m downloads/mo) - this readme is pretty extensive, with a TOC and other advanced features
 - [is-glob](https://www.npmjs.com/package/is-glob) (1.6m downloads/mo) - example of simple readme
-- [repeat-string](https://www.npmjs.com/package/is-glob) (2.2m downloads/mo) - example of another basic readme.
+- [repeat-string](https://www.npmjs.com/package/repeat-string) (2.2m downloads/mo) - example of another basic readme.
 
 **Quickstart**
 


### PR DESCRIPTION
repeat-string has the wrong link